### PR TITLE
returns null rather than false if key doesn't exist for retrieve function

### DIFF
--- a/lib/Memento/Client.php
+++ b/lib/Memento/Client.php
@@ -136,7 +136,7 @@ class Client
         $this->engine->setGroupKey($groupKey);
 
         if (!$this->engine->isValid($key)) {
-            return false;
+            return null;
         }
 
         return $this->engine->retrieve($key);


### PR DESCRIPTION
see #7 
