### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/console": "v2.5.0"
+        "symfony/console": "2.5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.3",


### PR DESCRIPTION
we should match any minor version for symfony/console 2.5

otherwise, conflicts happen when you try to check use memento with a version of `symfony` other than `2.5.0` 
