### PR TITLE
Adds TTL to cache entries to supersede expiry

### DIFF
--- a/lib/Memento/Engine/EngineAbstract.php
+++ b/lib/Memento/Engine/EngineAbstract.php
@@ -11,6 +11,8 @@ use Memento;
 
 abstract class EngineAbstract
 {
+    const DEFAULT_EXPIRES = 300;
+
     /*
     Since we can balance across multiple servers, decide which server a key resides on.
     */

--- a/lib/Memento/Engine/EngineInterface.php
+++ b/lib/Memento/Engine/EngineInterface.php
@@ -13,10 +13,14 @@ use Memento;
 interface EngineInterface
 {
     public function setGroupKey(Memento\Group\Key $groupKey = null);
-    public function exists(Memento\Key $key);
+    public function exists(Memento\Key $key, $expired = false);
+    public function expire(Memento\Key $key = null);
+    public function getExpires(Memento\Key $key = null);
+    public function getTtl(Memento\Key $key = null);
     public function invalidate(Memento\Key $key = null);
-    public function isValid(Memento\Key $key = null);
+    public function isValid(Memento\Key $key = null, $expired = false);
     public function keys();
-    public function store(Memento\Key $key, $value, $expires);
-    public function retrieve(Memento\Key $key);
+    public function store(Memento\Key $key, $value, $expires = null, $ttl = null);
+    public function terminate(Memento\Key $key = null);
+    public function retrieve(Memento\Key $key, $expired = false);
 }

--- a/lib/Memento/Engine/File.php
+++ b/lib/Memento/Engine/File.php
@@ -16,6 +16,10 @@ class File extends EngineAbstract implements EngineInterface
      */
     const DIR_PARTITION_COUNT = 1000;
 
+    const FILENAME_CACHE = 'cache';
+    const FILENAME_EXPIRES = 'expires';
+    const FILENAME_TTL = 'ttl';
+
     /**
      * storage path
      */
@@ -99,6 +103,15 @@ class File extends EngineAbstract implements EngineInterface
     }
 
     /**
+     * Gets the path to the ttl file
+     * Returns group path if possible.  Otherwise, returns key path
+     */
+    private function getTtlPath(Memento\Key $key = null)
+    {
+        return $this->getKeyPath($this->groupKey ? null : $key);
+    }
+
+    /**
      * Recursively removes a directory
      */
     private function rrmdir($dir)
@@ -122,13 +135,56 @@ class File extends EngineAbstract implements EngineInterface
     /**
      * Logical implementation of the exists() command
      */
-    public function exists(Memento\Key $key)
+    public function exists(Memento\Key $key, $expired = false)
     {
         $keyPath = $this->getKeyPath($key);
 
-        $cacheFile = $keyPath . DIRECTORY_SEPARATOR . 'cache';
+        $cacheFile = $keyPath . DIRECTORY_SEPARATOR . self::FILENAME_CACHE;
 
         return file_exists($cacheFile);
+    }
+
+    /**
+     * Logical implementation of the expire() command
+     */
+    public function expire(Memento\Key $key = null)
+    {
+        $expiresFile = $this->getExpiresPath($key) . DIRECTORY_SEPARATOR . self::FILENAME_EXPIRES;
+
+        $bytes = 0;
+        $now = time();
+        $expires = $now;
+        if (file_exists(dirname($expiresFile))) {
+            $bytes = file_put_contents($expiresFile, $expires, LOCK_EX);
+        }
+
+        return ($bytes > 0);
+    }
+
+    public function getExpires(Memento\Key $key = null)
+    {
+        $expiresFile = $this->getExpiresPath($key) . DIRECTORY_SEPARATOR . self::FILENAME_EXPIRES;
+
+        $now = time();
+        $expires = $now;
+        if (file_exists($expiresFile)) {
+            $expires = file_get_contents($expiresFile);
+        }
+
+        return $expires - $now;
+    }
+
+    public function getTtl(Memento\Key $key = null)
+    {
+        $ttlFile = $this->getTtlPath($key) . DIRECTORY_SEPARATOR . self::FILENAME_TTL;
+
+        $now = time();
+        $ttl = $now;
+        if (file_exists($ttlFile)) {
+            $ttl = file_get_contents($ttlFile);
+        }
+
+        return $ttl - $now;
     }
 
     /**
@@ -152,12 +208,12 @@ class File extends EngineAbstract implements EngineInterface
         // (e.g. '[GROUP PARTITION]/[GROUP]/[PARTITION]/[KEY]/cache')
         $iterator  = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($keyPath));
 
-        $regIterator = new \RegexIterator($iterator, '/\/[\d]+\/[\w\d]+\/cache$/i');
+        $regIterator = new \RegexIterator($iterator, '/\/[\d]+\/[\w\d]+\/' . self::FILENAME_CACHE .'$/i');
         $keys = array();
 
         foreach ($regIterator as $path) {
             // extract key from file path
-            preg_match('/\/(?<key>[\w\d]+)\/cache$/', $path->__toString(), $match);
+            preg_match('/\/(?<key>[\w\d]+)\/' . self::FILENAME_CACHE . '/', $path->__toString(), $match);
             if (!array_key_exists('key', $match) || empty($match['key'])) {
                 continue;
             }
@@ -173,11 +229,11 @@ class File extends EngineAbstract implements EngineInterface
     /**
      * Logical implementation of the retrieve() command
      */
-    public function retrieve(Memento\Key $key)
+    public function retrieve(Memento\Key $key, $expired = false)
     {
         $keyPath = $this->getKeyPath($key);
 
-        $cacheFile = $keyPath . DIRECTORY_SEPARATOR . 'cache';
+        $cacheFile = $keyPath . DIRECTORY_SEPARATOR . self::FILENAME_CACHE;
 
         if (!file_exists($cacheFile)) {
             return NULL;
@@ -197,18 +253,31 @@ class File extends EngineAbstract implements EngineInterface
     /**
      * Logical implementation of the store() command
      */
-    public function store(Memento\Key $key, $value, $expires)
+    public function store(Memento\Key $key, $value, $expires = null, $ttl = null)
     {
         $keyPath = $this->getKeyPath($key);
         $data = serialize($value);
 
-        $expiresFile = $this->getExpiresPath($key) . DIRECTORY_SEPARATOR . 'expires';
-        $cacheFile = $keyPath . DIRECTORY_SEPARATOR . 'cache';
+        $cacheFile = $keyPath . DIRECTORY_SEPARATOR . self::FILENAME_CACHE;
+        $expiresFile = $this->getExpiresPath($key) . DIRECTORY_SEPARATOR . self::FILENAME_EXPIRES;
+        $ttlFile = $this->getTtlPath($key) . DIRECTORY_SEPARATOR . self::FILENAME_TTL;
 
+        // if no expires specified use default of 5 minutes
+        if (!is_numeric($expires)) {
+            $expires = self::DEFAULT_EXPIRES;
+        }
         $expiresBytes = file_put_contents($expiresFile, time() + $expires, LOCK_EX);
+
+        // ttl is when the cache is actually okay for deletion
+        if (!is_numeric($ttl)) {
+            $ttl = $expires;
+        }
+
+        $ttlBytes = file_put_contents($ttlFile, time() + $ttl, LOCK_EX);
+
         $cacheBytes = file_put_contents($cacheFile, $data, LOCK_EX);
 
-        if ($expiresBytes > 0 && $cacheBytes > 0) {
+        if ($expiresBytes > 0 && $ttlBytes > 0 && $cacheBytes > 0) {
             return true;
         }
 
@@ -216,12 +285,44 @@ class File extends EngineAbstract implements EngineInterface
     }
 
     /**
+     * Duplicate of the invalidate command
+     */
+    public function terminate(Memento\Key $key = null)
+    {
+        $keyPath = $this->getKeyPath($key);
+
+        return $this->rrmdir($keyPath);
+    }
+
+    /**
      * Logical implementation of the isValid() command
      */
-    public function isValid(Memento\Key $key = null)
+    public function isValid(Memento\Key $key = null, $expired = false)
     {
         $keyPath = $this->getExpiresPath($key);
-        $expiresFile = $keyPath . DIRECTORY_SEPARATOR . 'expires';
+
+        // if we are to look for expired files that exist, we must examine ttl instead
+        if ($expired === true) {
+            $ttlPath = $this->getTtlPath($key);
+            $ttlFile = $ttlPath . DIRECTORY_SEPARATOR . self::FILENAME_TTL;
+
+            if (!file_exists($ttlFile)) {
+                return false;
+            }
+
+            $ttl = intval(file_get_contents($ttlFile));
+            if (!is_numeric($ttl)) {
+                return false;
+            }
+
+            if (time() > $ttl) {
+                return false;
+            }
+
+            return true;
+        }
+
+        $expiresFile = $keyPath . DIRECTORY_SEPARATOR . self::FILENAME_EXPIRES;
 
         if (!file_exists($expiresFile)) {
             return false;

--- a/lib/Memento/Hash.php
+++ b/lib/Memento/Hash.php
@@ -33,4 +33,9 @@ class Hash
      * Used for field name to store valid flag on a hash
      */
     const FIELD_VALID   = 'valid';
+
+    /**
+     * Used for field name to store ttl data on a hash
+     */
+    const FIELD_TTL = 'ttl';
 }

--- a/test/Memento/Test/Harness.php
+++ b/test/Memento/Test/Harness.php
@@ -14,6 +14,11 @@ abstract class Harness extends \PHPUnit_Framework_TestCase
         return 60;
     }
 
+    public function getTtl()
+    {
+        return $this->getExpires() + 5;
+    }
+
     public function getGroupKey()
     {
         if (!$this->groupKey) {

--- a/test/Memento/Test/SingleTest.php
+++ b/test/Memento/Test/SingleTest.php
@@ -11,6 +11,14 @@ class SingleTest extends Harness
     {
         $success = $client->store($this->getKey(), array('foo' => 'bar'), $this->getExpires());
         $this->assertTrue($success);
+        $this->assertEquals($this->getExpires(), $client->getExpires($this->getKey()));
+        $this->assertEquals($this->getExpires(), $client->getTtl($this->getKey())); // default should be the same as expires
+
+        // store with ttl
+        $success = $client->store($this->getKey(), array('foo' => 'bar'), $this->getExpires(), $this->getTtl());
+        $this->assertTrue($success);
+        $this->assertLessThanOrEqual($this->getExpires(), $client->getExpires($this->getKey()));
+        $this->assertLessThanOrEqual($this->getTtl(), $client->getTtl($this->getKey()));
     }
 
     /** @dataProvider provideClients */
@@ -42,7 +50,6 @@ class SingleTest extends Harness
     public function testInvalidate(Memento\Client $client)
     {
         $client->store($this->getKey(), true);
-
         $invalid = $client->invalidate($this->getKey());
         $this->assertTrue($invalid);
         $exists = $client->exists($this->getKey());
@@ -50,11 +57,36 @@ class SingleTest extends Harness
     }
 
     /** @dataProvider provideClients */
+    public function testTerminate(Memento\Client $client)
+    {
+        $client->store($this->getKey(), true);
+
+        $terminated = $client->terminate($this->getKey());
+        $this->assertTrue($terminated);
+        $exists = $client->exists($this->getKey());
+        $this->assertFalse($exists);
+    }
+
+    /** @dataProvider provideClients */
     public function testExpires(Memento\Client $client)
     {
-        $client->store($this->getKey(), array('foo' => 'bar'), 1);
+        $client->store($this->getKey(), array('foo' => 'bar'), 1, $ttl = 5);
         sleep(3);
         $exists = $client->exists($this->getKey());
         $this->assertFalse($exists);
+
+        // check if cache exists but include expired caches
+        $exists = $client->exists($this->getKey(), true);
+        $this->assertTrue($exists);
+
+        $client->store($this->getKey(), array('foo' => 'bar'), $this->getExpires(), $this->getTtl());
+        $this->assertTrue($client->exists($this->getKey()));
+        $client->expire($this->getKey());
+        sleep(1);
+        $this->assertFalse($client->exists($this->getKey()));
+
+        // check if cache exists but include expired caches
+        $exists = $client->exists($this->getKey(), true);
+        $this->assertTrue($exists);
     }
 }


### PR DESCRIPTION
Adds optional TTL value that can be set on cache keys. This should be longer than the expires value and reflects the absolute time that a cache artifact will be available. If expires is set then the cache will still be stored until the TTL value, but not available unless specified on cache lookups. TTL and expires both default to one hour if not specified.

Examples:
```php
$key = new Memento\Key('com.example.key');
$expires = 3600;
$ttl = 7200;

// stores cache key with a one hour expires and two hour TTL
$memento->store($key, ['mydata'], $expires, $ttl);

// up to one hour
$memento-> exists($key); // returns true

// after one hour
$memento-> exists($key); // returns false

// after one hour up to two hours
$getExpired = true;
$memento-> exists($key, $getExpired); // returns true
```

NOTE: This change is fully backwards compatible

Tests all pass
```[httpd@localhost.dev memento]$ ./vendor/phpunit/phpunit/phpunit --stop-on-failure
PHPUnit 4.1.3 by Sebastian Bergmann.

Configuration read from /source/memento/phpunit.xml

................................................................. 65 / 67 ( 97%)
..

Time: 42.1 seconds, Memory: 5.00MB

OK (67 tests, 187 assertions)```